### PR TITLE
add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*~
+.stack-work
+tests/output/*


### PR DESCRIPTION
I know it's a bit late, but the madness has to end. please add .gitignore to ignore

* filenames with trailing ~
* .stack-work
* anything in tests/output